### PR TITLE
Add action to deploy a `pkgdown` website to GitHub pages

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,9 +15,10 @@ cran-comments.md
 ^doc$
 ^Meta$
 ^docs$
-_pkgdown.yml
 ^\.github$
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
 ^codecov\.yml$
 ^LICENSE\.md$
+^_pkgdown\.yml$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ inst/doc
 test-data
 doc
 Meta
+docs


### PR DESCRIPTION
Ran `usethis::use_github_action("pkgdown")`.  It looks like everything was set up except a missing GitHub actions workflow.  Might need to change some settings that I don't have access to.