### PR TITLE
return length 1 numeric vector even when cached

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 * `rnpn` now has `dplyr` as a dependency instead of `plyr`
 * `rnpn` now uses `httr2` instead of `httr` internally for functions that get observational data
 * `...` is no longer used for functions that get observational data
+* Fixed a bug (#42) where returned value of `npn_get_agdd_point_data()` was inconsistent depending on whether it was cached or not.
 
 # rnpn 1.2.9 (2024-08-18)
 

--- a/R/npn_geoserver.R
+++ b/R/npn_geoserver.R
@@ -178,7 +178,7 @@ npn_get_agdd_point_data <- function(
   # pull it from there.
   cached_value <- npn_check_point_cached(layer, lat, long, date)
   if (!is.null(cached_value)) {
-    return(cached_value)
+    return(cached_value$value)
   }
   tryCatch({
     url <- paste0(
@@ -223,7 +223,7 @@ npn_get_agdd_point_data <- function(
   # Once the value is known, then cache it in global memory so the script doesn't try to ask for the same
   # data point more than once.
   #
-  # TODO: Break this into it's own function
+  # TODO: Break this into it's own function or possibly cache the whole response with `httr2::req_cache()`
   if (store_data) {
     if (is.null(pkg.env$point_values)) {
       pkg.env$point_values <- data.frame(


### PR DESCRIPTION
Closes #42.  A simple change that makes the return value of `npn_get_agdd_point_data()` consistent.