### PR TITLE
Unnest tibbles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     magrittr,
     rlang,
     tibble,
+    tidyr,
     xml2
 Suggests:
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 * `rnpn` now uses `httr2` instead of `httr`
 * `...` is no longer used for functions that get observational data
 * Fixed a bug (#42) where returned value of `npn_get_agdd_point_data()` was inconsistent depending on whether it was cached or not.
+* `npn_abundance_categories()`, `npn_phenophases_by_species()`, and `npn_get_phenophases_for_taxon()` no longer return a data frames containing list-columns.  The results are now unnested automatically.
+* `npn_groups(use_hierarchy = TRUE)` now returns a nested list rather than a tibble with a list-column.
 
 # rnpn 1.2.9 (2024-08-18)
 

--- a/R/npn_partner_groups.R
+++ b/R/npn_partner_groups.R
@@ -5,10 +5,11 @@
 #' results.
 #'
 #' @param use_hierarchy Boolean indicating whether or not the list of networks
-#'   should be represented in a hierarchy. Defaults to `FALSE`.
+#'   should be represented in a hierarchy. If `TRUE`, the result will be
+#'   returned as a nested list rather than a tibble. Defaults to `FALSE`.
 #' @param ... Currently unused.
-#' @returns A tibble of partner groups, including `network_id` and
-#'   `network_name`.
+#' @returns A tibble (or nested list if `use_hierarchy = TRUE`) of partner
+#'   groups, including `network_id` and `network_name`.
 #' @export
 #' @examples \dontrun{
 #' npn_groups()
@@ -24,8 +25,11 @@ npn_groups <- function(use_hierarchy = FALSE, ...) {
   }
 
   resp <- httr2::req_perform(req)
-  out <- httr2::resp_body_json(resp, simplifyVector = TRUE)
+  out <- httr2::resp_body_json(resp, simplifyVector = !use_hierarchy)
   #return:
-  tibble::as_tibble(out)
-  #TODO output contains list column that cannot be easily unnested.
+  if (inherits(out, "data.frame")) {
+    return(tibble::as_tibble(out))
+  } else {
+    return(out)
+  }
 }

--- a/R/npn_phenophases.R
+++ b/R/npn_phenophases.R
@@ -93,11 +93,10 @@ npn_phenophases_by_species <- function(species_ids, date, ...) {
 
   resp <- httr2::req_perform(req)
   out <- httr2::resp_body_json(resp, simplifyVector = TRUE)
-
+  #unnest
+  out <- tidyr::unnest(out, tidyr::any_of("phenophases"))
   #return:
   tibble::as_tibble(out)
-  #TODO this data frame has a list-column.  Consider unnesting?
-  # tidyr::unnest(tibble::as_tibble(out), phenophases)
 }
 
 #' Get Pheno Classes
@@ -183,11 +182,10 @@ npn_get_phenophases_for_taxon <- function(family_ids = NULL,
     )
   resp <- httr2::req_perform(req)
   out <- httr2::resp_body_json(resp, simplifyVector = TRUE)
-
+  #unnest
+  out <- tidyr::unnest(out, tidyr::any_of("phenophases"))
   #return:
   tibble::as_tibble(out)
-  #TODO this data frame has a list-column.  Consider unnesting?
-  # tidyr::unnest(tibble::as_tibble(out), phenophases)
 }
 
 #' Get Abundance Categories
@@ -207,9 +205,9 @@ npn_abundance_categories <- function(...) {
     httr2::req_url_path_append('phenophases/getAbundanceCategories.json')
   resp <- httr2::req_perform(req)
   out <- httr2::resp_body_json(resp, simplifyVector = TRUE)
+  #unnest list column
+  out <- tidyr::unnest(out, tidyr::any_of("category_values"))
   #return:
   tibble::as_tibble(out)
-  #TODO: consider unnesting
-  #tibble::as_tibble(out) %>% tidyr::unnest(category_values)
 }
 

--- a/man/npn_groups.Rd
+++ b/man/npn_groups.Rd
@@ -8,13 +8,14 @@ npn_groups(use_hierarchy = FALSE, ...)
 }
 \arguments{
 \item{use_hierarchy}{Boolean indicating whether or not the list of networks
-should be represented in a hierarchy. Defaults to \code{FALSE}.}
+should be represented in a hierarchy. If \code{TRUE}, the result will be
+returned as a nested list rather than a tibble. Defaults to \code{FALSE}.}
 
 \item{...}{Currently unused.}
 }
 \value{
-A tibble of partner groups, including \code{network_id} and
-\code{network_name}.
+A tibble (or nested list if \code{use_hierarchy = TRUE}) of partner
+groups, including \code{network_id} and \code{network_name}.
 }
 \description{
 Returns a list of all groups participating in the NPN's data collection

--- a/man/rnpn-package.Rd
+++ b/man/rnpn-package.Rd
@@ -26,12 +26,12 @@ Authors:
   \item Scott Chamberlain
   \item Lee Marsh
   \item Kevin Wong
+  \item Eric R Scott (\href{https://orcid.org/0000-0002-7430-7879}{ORCID})
 }
 
 Other contributors:
 \itemize{
   \item David LeBauer [contributor]
-  \item Eric R Scott [contributor]
 }
 
 }

--- a/tests/testthat/test-npn-partners.R
+++ b/tests/testthat/test-npn-partners.R
@@ -9,7 +9,6 @@ test_that("npn_groups works", {
   expect_type(groups$network_name, "character")
   expect_gt(nrow(groups),50)
 
-  groups <- npn_groups(TRUE)
-  expect_s3_class(groups, "data.frame")
-  expect_type(groups$network_name, "character")
+  groups <- npn_groups(use_hierarchy = TRUE)
+  expect_type(groups, "list")
 })

--- a/tests/testthat/test-npn-phenophases.R
+++ b/tests/testthat/test-npn-phenophases.R
@@ -91,7 +91,7 @@ test_that("npn_get_phenophases_for_taxon works", {
 
   expect_s3_class(pp, "data.frame")
   expect_type(pp$class_name, "character")
-  expect_equal(nrow(pp), 1)
+  expect_equal(nrow(pp), 21)
 
   vcr::use_cassette("npn_get_phenophases_for_taxon_2", {
     pp <- npn_get_phenophases_for_taxon(class_ids=c(5,6), date="2018-05-05")
@@ -99,7 +99,7 @@ test_that("npn_get_phenophases_for_taxon works", {
 
   expect_s3_class(pp, "data.frame")
   expect_type(pp$class_name, "character")
-  expect_equal(nrow(pp), 2)
+  expect_equal(nrow(pp), 28)
 
   vcr::use_cassette("npn_get_phenophases_for_taxon_3", {
     pp <- npn_get_phenophases_for_taxon(family_ids=c(267,268),date="2018-05-05")
@@ -107,7 +107,7 @@ test_that("npn_get_phenophases_for_taxon works", {
 
   expect_s3_class(pp, "data.frame")
   expect_type(pp$family_name, "character")
-  expect_equal(nrow(pp), 2)
+  expect_equal(nrow(pp), 24)
 
   vcr::use_cassette("npn_get_phenophases_for_taxon_4", {
     pp <- npn_get_phenophases_for_taxon(order_ids=c(74,75), date="2018-05-05", return_all = 0)
@@ -115,7 +115,7 @@ test_that("npn_get_phenophases_for_taxon works", {
 
   expect_s3_class(pp, "data.frame")
   expect_type(pp$order_name, "character")
-  expect_equal(nrow(pp), 2)
+  expect_equal(nrow(pp), 21)
 
 
   vcr::use_cassette("npn_get_phenophases_for_taxon_5", {
@@ -124,7 +124,7 @@ test_that("npn_get_phenophases_for_taxon works", {
 
   expect_s3_class(pp, "data.frame")
   expect_type(pp$order_name, "character")
-  expect_equal(nrow(pp), 2)
+  expect_equal(nrow(pp), 155)
 
   skip("unclear if this last one is supposed to work or error")
   vcr::use_cassette("npn_get_phenophases_for_taxon_6", {


### PR DESCRIPTION
Closes #52.  Functions that previously returned tibbles with [list-columns](https://tidyr.tidyverse.org/articles/nest.html) are now unnested with the exception of `npn_groups(use_hierarchy = TRUE)`.  `npn_groups(use_hierarchy = FALSE)` is returned as a tibble just as before, but when `use_hierarchy = TRUE` it now returns a nested list.  Previously it returned a tibble with a list-column that couldn't be easily unnested (because some elements of that list-column were dataframes with list-columns, etc.)