### PR TITLE
Fix for #87 — force `update_datetime` to be a datetime

### DIFF
--- a/R/npn_data_download.R
+++ b/R/npn_data_download.R
@@ -689,6 +689,11 @@ npn_get_data_by_year <- function(endpoint,
 #' @returns A tibble of the requested data. If a `download_path` was specified,
 #'   the file path is returned.
 #' @keywords internal
+#' @examples \dontrun{
+#' npn_get_data(
+#'  url = "https://services.usanpn.org/npn_portal//observations/getObservations.ndjson?",
+#'  query = list(request_src = "Unit%20Test", climate_data = "0", `species_id[1]` = "6", start_date = "2010-01-01", end_date = "2010-12-31")
+#' }
 npn_get_data <- function(url,
                          query,
                          download_path = NULL,
@@ -722,7 +727,9 @@ npn_get_data <- function(url,
       dplyr::mutate(dplyr::across(dplyr::where(is.numeric),
                                   \(x) ifelse(x == -9999, NA_real_, x))) %>%
       dplyr::mutate(dplyr::across(dplyr::where(is.character),
-                                  \(x) ifelse(x == "-9999", NA_character_, x)))
+                                  \(x) ifelse(x == "-9999", NA_character_, x))) %>%
+      dplyr::mutate(update_datetime = as.POSIXct(update_datetime),
+                    intensity_value = as.character(intensity_value))
 
     # Reconcile all the points in the frame with the SIX leaf raster,
     # if it's been requested.

--- a/R/npn_data_download.R
+++ b/R/npn_data_download.R
@@ -691,8 +691,15 @@ npn_get_data_by_year <- function(endpoint,
 #' @keywords internal
 #' @examples \dontrun{
 #' npn_get_data(
-#'  url = "https://services.usanpn.org/npn_portal//observations/getObservations.ndjson?",
-#'  query = list(request_src = "Unit%20Test", climate_data = "0", `species_id[1]` = "6", start_date = "2010-01-01", end_date = "2010-12-31")
+#'   url = "https://services.usanpn.org/npn_portal//observations/getObservations.ndjson?",
+#'   query = list(
+#'     request_src = "Unit%20Test",
+#'     climate_data = "0",
+#'     `species_id[1]` = "6",
+#'     start_date = "2010-01-01",
+#'     end_date = "2010-12-31"
+#'   )
+#' )
 #' }
 npn_get_data <- function(url,
                          query,

--- a/R/npn_data_download.R
+++ b/R/npn_data_download.R
@@ -724,12 +724,21 @@ npn_get_data <- function(url,
                                promote_num_to_string = TRUE) %>%
       tibble::as_tibble() %>%
       #replace missing data indicator with NA
-      dplyr::mutate(dplyr::across(dplyr::where(is.numeric),
-                                  \(x) ifelse(x == -9999, NA_real_, x))) %>%
-      dplyr::mutate(dplyr::across(dplyr::where(is.character),
-                                  \(x) ifelse(x == "-9999", NA_character_, x))) %>%
-      dplyr::mutate(update_datetime = as.POSIXct(update_datetime),
-                    intensity_value = as.character(intensity_value))
+      dplyr::mutate(
+        dplyr::across(dplyr::where(is.numeric),
+                      function(x) ifelse(x == -9999, NA_real_, x))
+      ) %>%
+      dplyr::mutate(
+        dplyr::across(dplyr::where(is.character),
+                      function(x) ifelse(x == "-9999", NA_character_, x))
+      ) %>%
+      #handle some columns that may be read in as the wrong type if they happen
+      #to be all NAs (#87). `any_of()` is used because not all endpoints will
+      #return these columns!
+      dplyr::mutate(
+        dplyr::across(dplyr::any_of("update_datetime"), as.POSIXct),
+        dplyr::across(dplyr::any_of("intensity_value"), as.character)
+      )
 
     # Reconcile all the points in the frame with the SIX leaf raster,
     # if it's been requested.

--- a/R/npn_data_download.R
+++ b/R/npn_data_download.R
@@ -743,7 +743,8 @@ npn_get_data <- function(url,
       #to be all NAs (#87). `any_of()` is used because not all endpoints will
       #return these columns!
       dplyr::mutate(
-        dplyr::across(dplyr::any_of("update_datetime"), as.POSIXct),
+        dplyr::across(dplyr::any_of("update_datetime"),
+                      function(x) as.POSIXct(x, tz = "UTC")),
         dplyr::across(dplyr::any_of("intensity_value"), as.character)
       )
 

--- a/man/npn_get_data.Rd
+++ b/man/npn_get_data.Rd
@@ -34,4 +34,11 @@ the file path is returned.
 \description{
 Generic utility function for querying data from the NPN data services.
 }
+\examples{
+\dontrun{
+npn_get_data(
+ url = "https://services.usanpn.org/npn_portal//observations/getObservations.ndjson?",
+ query = list(request_src = "Unit\%20Test", climate_data = "0", `species_id[1]` = "6", start_date = "2010-01-01", end_date = "2010-12-31")
+}
+}
 \keyword{internal}

--- a/man/npn_get_data.Rd
+++ b/man/npn_get_data.Rd
@@ -37,8 +37,15 @@ Generic utility function for querying data from the NPN data services.
 \examples{
 \dontrun{
 npn_get_data(
- url = "https://services.usanpn.org/npn_portal//observations/getObservations.ndjson?",
- query = list(request_src = "Unit\%20Test", climate_data = "0", `species_id[1]` = "6", start_date = "2010-01-01", end_date = "2010-12-31")
+  url = "https://services.usanpn.org/npn_portal//observations/getObservations.ndjson?",
+  query = list(
+    request_src = "Unit\%20Test",
+    climate_data = "0",
+    `species_id[1]` = "6",
+    start_date = "2010-01-01",
+    end_date = "2010-12-31"
+  )
+)
 }
 }
 \keyword{internal}


### PR DESCRIPTION
Fixes #87. Unfortunately more of these could pop up in the future.  If they do, I'll try to come up with a more generic fix.  Didn't update NEWS because I'm pretty sure this bug was introduced in this version.