### PR TITLE
Add retry and progress bar

### DIFF
--- a/R/base-reqs.R
+++ b/R/base-reqs.R
@@ -8,12 +8,15 @@ base_geoservices_url <- "https://services.usanpn.org/geo-services/v1/"
 #TODO consider adding retry and rate-limiting, maybe caching?
 base_req <-
   httr2::request(base_portal_url) %>%
+  httr2::req_retry(max_tries = 3) %>%
   httr2::req_user_agent("rnpn (https://github.com/usa-npn/rnpn/)")
 
 base_req_geoserver <-
   httr2::request(base_geoserver_url) %>%
+  httr2::req_retry(max_tries = 3) %>%
   httr2::req_user_agent("rnpn (https://github.com/usa-npn/rnpn/)")
 
 base_req_geoservices <-
   httr2::request(base_geoservices_url) %>%
+  httr2::req_retry(max_tries = 3) %>%
   httr2::req_user_agent("rnpn (https://github.com/usa-npn/rnpn/)")

--- a/R/npn_data_download.R
+++ b/R/npn_data_download.R
@@ -774,9 +774,9 @@ npn_get_data <- function(endpoint,
 
   req <- base_req %>%
     httr2::req_url_path_append(endpoint) %>%
-    # httr2::req_progress(type = "down") %>% #doesn't work—only for file downloads
     httr2::req_method("POST") %>%
-    httr2::req_body_form(!!!query)
+    httr2::req_body_form(!!!query) %>%
+    httr2::req_progress() #adds progress bar for long downloads
 
   #define data wrangling function to be run on entire df or by chunks of 5000
   #rows


### PR DESCRIPTION
Adds retry (max tries = 3) to all requests and adds progress bars to downloads by `npn_get_data()`.  Whether or not the download progress bar shows up seems really inconsistent to me, and I don't think it shows progress when the API servers are slow but the JSON download is fast.  On the other hand, there's little overhead for adding them I think.