### PR TITLE
Add action to run tests on API

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,4 @@ notes/
 ^pkgdown$
 ^CITATION.cff$
 ^CONTRIBUTING\.md$
+.vscode/

--- a/.github/workflows/API-test.yaml
+++ b/.github/workflows/API-test.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         R_KEEP_PKG_SOURCE: yes
-        RNPN_SKIP_LONG_TEST: false #don't skip long-running tests
+        RNPN_SKIP_LONG_TESTS: false #don't skip long-running tests
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/API-test.yaml
+++ b/.github/workflows/API-test.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    cron: '0 12 1 * *' #at noon on the first of the month
+    - cron: '0 12 1 * *' #at noon on the first of the month
 # for testing only:
   pull_request:
     branches: [main, master]

--- a/.github/workflows/API-test.yaml
+++ b/.github/workflows/API-test.yaml
@@ -1,0 +1,37 @@
+on:
+  schedule:
+    cron: '0 12 1 * *' #at noon on the first of the month
+# for testing only:
+  pull_request:
+    branches: [main, master]
+
+name: API-test
+
+jobs:
+  API-test:
+    runs-on: ubuntu-latest
+    env:
+        GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        R_KEEP_PKG_SOURCE: yes
+        RNPN_SKIP_LONG_TEST: false #don't skip long-running tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Remove `vcr` fixtures
+        run: rm -rf ./tests/fixtures
+        shell: bash
+
+      #TODO: maybe just run test() and not all of check()?
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/.github/workflows/API-test.yaml
+++ b/.github/workflows/API-test.yaml
@@ -8,11 +8,8 @@ on:
       skip_long:
         description: "Skip long-running tests?"
         required: true
-        default: 'false'
-        type: choice
-        options:
-          - false
-          - true
+        default: false
+        type: boolean
 
 # for testing only:
   pull_request:
@@ -27,7 +24,7 @@ jobs:
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         R_KEEP_PKG_SOURCE: yes
         #don't skip long-running tests unless specified otherwise in input of workflow dispatch
-        RNPN_SKIP_LONG_TESTS: ${{ inputs.skip_long || false }} 
+        RNPN_SKIP_LONG_TESTS: ${{ inputs.skip_long || 'false' }} 
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/API-test.yaml
+++ b/.github/workflows/API-test.yaml
@@ -1,6 +1,19 @@
 on:
+ # run at noon on the first of the month
   schedule:
-    - cron: '0 12 1 * *' #at noon on the first of the month
+    - cron: '0 12 1 * *' 
+ # or when button is clicked in the Actions tab on GitHub
+  workflow_dispatch: 
+    inputs:
+      skip_long:
+        description: "Skip long-running tests?"
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - false
+          - true
+
 # for testing only:
   pull_request:
     branches: [main, master]
@@ -13,7 +26,8 @@ jobs:
     env:
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         R_KEEP_PKG_SOURCE: yes
-        RNPN_SKIP_LONG_TESTS: false #don't skip long-running tests
+        #don't skip long-running tests unless specified otherwise in input of workflow dispatch
+        RNPN_SKIP_LONG_TESTS: ${{ inputs.skip_long || false }} 
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Meta
 docs
 notes/*.tiff
 nohup.out
+.vscode/


### PR DESCRIPTION
Adds an action that runs on the 1st of every month (this can be changed) that is basically a simplified version of `R-CMD-check.yaml` with a few important changes:

1. It only runs on ubuntu-latest with the release version of R
1. It sets the environment variable `RNPN_SKIP_LONG_TEST: false` to not skip long-running tests
2. It deletes the `/tests/fixtures` folder before running `check()`