### PR TITLE
Avoid cryptic error message that pops up when no records meet search criteria in one or more years

### DIFF
--- a/R/npn_data_download.R
+++ b/R/npn_data_download.R
@@ -716,13 +716,14 @@ npn_get_data_by_year <- function(
       # returned data. The data doesn't have to be combined if there was
       # no previous iteration / the results were empty
       if (!is.null(data) && is.null(download_path)) {
+        first_year <- FALSE
         if (!is.null(all_data)) {
           all_data <- dplyr::bind_rows(all_data, data)
         } else {
           all_data <- data
         }
       }
-      if (!is.null(data)) {
+      if (!is.null(data) && !is.null(download_path) && file.exists(data)) {
         first_year <- FALSE
       }
     }
@@ -910,9 +911,15 @@ npn_get_data <- function(
   # assume that memory could be a limitation and wrangle data 5000 rows at a
   # time and append to the CSV file specified in `download_path`
   if (is.null(download_path)) {
-    dtm <-
-      httr2::resp_body_json(resp, simplifyVector = TRUE) %>%
-      wrangle_dl_data()
+    dtm <- httr2::resp_body_json(resp, simplifyVector = TRUE)
+    # If dtm is an empty list because there are no records, set equal to NULL
+    # and print message
+    if (is.null(dim(dtm))) {
+      dtm <- NULL
+      message(paste0("No records in ", substring(query$start_date, 1, 4)))
+    } else {
+      dtm <- wrangle_dl_data(dtm)
+    }
     return(dtm)
   } else {
     #resp$body is a path to an .ndjson file

--- a/R/npn_data_download.R
+++ b/R/npn_data_download.R
@@ -912,10 +912,10 @@ npn_get_data <- function(
   # time and append to the CSV file specified in `download_path`
   if (is.null(download_path)) {
     dtm <- httr2::resp_body_json(resp, simplifyVector = TRUE)
-    # If dtm is an empty list because there are no records, set equal to NULL
-    # and print message
+    # If dtm is an empty list because there are no records, convert it into an
+    # empty tibble
     if (is.null(dim(dtm))) {
-      dtm <- NULL
+      dtm <- dplyr::tibble()
       message(paste0("No records in ", substring(query$start_date, 1, 4)))
     } else {
       dtm <- wrangle_dl_data(dtm)

--- a/R/npn_data_download.R
+++ b/R/npn_data_download.R
@@ -830,6 +830,7 @@ npn_get_data <- function(
             "observer_status_conflict_flag_individual_ids",
             "in-phase_search_method",
             "in-phase_per_hr_search",
+            "state",
             #sometimes get parsed as numeric:
             "intensity_value",
             "abundance_value"

--- a/tests/fixtures/npn_download_no_records.yml
+++ b/tests/fixtures/npn_download_no_records.yml
@@ -1,0 +1,27 @@
+http_interactions:
+- request:
+    method: post
+    uri: https://services.usanpn.org/npn_portal/observations/getSummarizedData.json
+    body:
+      encoding: ''
+      string: ''
+    headers: []
+  response:
+    status:
+      status_code: 200
+      message: OK
+    headers:
+      date: Wed, 21 May 2025 15:39:06 GMT
+      content-type: application/json
+      content-length: '2'
+      server: Apache/2.4.62 () PHP/5.5.38
+      x-powered-by: PHP/5.5.38
+      access-control-allow-origin: '*'
+      access-control-allow-headers: origin, x-requested-with, content-type
+      access-control-allow-methods: PUT, GET, POST, DELETE, OPTIONS
+    body:
+      encoding: ''
+      file: no
+      string: '[]'
+  recorded_at: 2025-05-21 15:39:06 GMT
+  recorded_with: vcr/1.6.0, webmockr/1.0.0

--- a/tests/testthat/test-npn-observations.R
+++ b/tests/testthat/test-npn-observations.R
@@ -2,15 +2,27 @@
 # mocked and are skipped
 # https://github.com/ropensci/vcr/issues/270
 
-skip_long_tests <- as.logical(Sys.getenv("RNPN_SKIP_LONG_TESTS", unset = "true"))
+skip_long_tests <- as.logical(Sys.getenv(
+  "RNPN_SKIP_LONG_TESTS",
+  unset = "true"
+))
 
 test_that("no request source blocked", {
   skip_on_cran()
 
   expect_error(npn_download_status_data(request_source = NULL, years = 2013))
-  expect_error(npn_download_individual_phenometrics(request_source = NULL, years = 2013))
-  expect_error(npn_download_site_phenometrics(request_source = NULL, years = 2013))
-  expect_error(npn_download_magnitude_phenometrics(request_source = NULL, years = 2013))
+  expect_error(npn_download_individual_phenometrics(
+    request_source = NULL,
+    years = 2013
+  ))
+  expect_error(npn_download_site_phenometrics(
+    request_source = NULL,
+    years = 2013
+  ))
+  expect_error(npn_download_magnitude_phenometrics(
+    request_source = NULL,
+    years = 2013
+  ))
 })
 
 test_that("npn_download_status_data() works", {
@@ -29,7 +41,7 @@ test_that("npn_download_status_data() works", {
   skip_if_not(check_service(), "Service is down")
 
   ## Would be ideal to capture this with vcr, but doesn't work with httr2 downloads yet: https://github.com/ropensci/vcr/issues/270
-  some_data_file  <- npn_download_status_data(
+  some_data_file <- npn_download_status_data(
     request_source = "Unit Test",
     years = 2013,
     species_ids = c(6),
@@ -41,8 +53,10 @@ test_that("npn_download_status_data() works", {
   expect_equal(
     read.csv(some_data_file) %>%
       tibble::as_tibble() %>%
-      dplyr::mutate(update_datetime = as.POSIXct(update_datetime, tz = "UTC"),
-                    abundance_value = as.character(abundance_value)),
+      dplyr::mutate(
+        update_datetime = as.POSIXct(update_datetime, tz = "UTC"),
+        abundance_value = as.character(abundance_value)
+      ),
     some_data
   )
 })
@@ -122,6 +136,18 @@ test_that("phenometrics downloads work", {
 
   expect_gt(num_mag_custom, num_mag_default)
 
+  expect_message(
+    dl <- npn_download_individual_phenometrics(
+      request_source = 'erinz',
+      years = 2009,
+      species_ids = 1612
+    ),
+    "No records in 2009"
+  )
+
+  #remove one of these depending on which you decide to return on this error
+  expect_equal(dl, dplyr::tibble())
+  expect_null(dl)
 })
 
 test_that("custom period works", {
@@ -168,12 +194,15 @@ test_that("custom period works", {
 
   #just crude checks that they aren't identical
   expect_false(
-    all(indiv_standard$last_yes_month[1:20] ==
-          indiv_wateryr$last_yes_month[1:20])
+    all(
+      indiv_standard$last_yes_month[1:20] == indiv_wateryr$last_yes_month[1:20]
+    )
   )
   expect_false(
-    all(site_standard$mean_last_yes_doy[1:20] ==
-          site_wateryr$mean_last_yes_doy[1:20])
+    all(
+      site_standard$mean_last_yes_doy[1:20] ==
+        site_wateryr$mean_last_yes_doy[1:20]
+    )
   )
 })
 
@@ -187,12 +216,12 @@ test_that("file download works", {
   test_download_path <- withr::local_tempfile(fileext = ".csv")
 
   # vcr::use_cassette("downloads", {
-    status_dl_file <- npn_download_status_data(
-      request_source = "Unit Test",
-      years = 2013,
-      species_ids = c(6),
-      download_path = test_download_path
-    )
+  status_dl_file <- npn_download_status_data(
+    request_source = "Unit Test",
+    years = 2013,
+    species_ids = c(6),
+    download_path = test_download_path
+  )
   # })
 
   expect_true(file.exists(status_dl_file))
@@ -202,7 +231,6 @@ test_that("file download works", {
   expect_gt(nrow(some_data), 1000)
   expect_type(some_data$species_id, "integer")
   expect_equal(some_data[1, ]$species_id, 6)
-
 
   some_data <- npn_download_magnitude_phenometrics(
     request_source = "Unit Test",
@@ -217,7 +245,6 @@ test_that("file download works", {
   expect_gt(nrow(some_data), 10)
   expect_type(some_data$species_id, "integer")
   expect_equal(some_data[1, ]$species_id, 6)
-
 })
 
 test_that("climate data flag works", {
@@ -260,7 +287,6 @@ test_that("climate data flag works", {
 
   expect_s3_class(some_data, "data.frame")
   expect_null(some_data$tmin_winter)
-
 })
 
 
@@ -304,7 +330,7 @@ test_that("higher taxonomic ordering works for status data", {
   expect_type(some_data$order_id, "integer")
   expect_equal(some_data[1, ]$order_id, 95)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
 
@@ -323,7 +349,7 @@ test_that("higher taxonomic ordering works for status data", {
   expect_type(some_data$class_id, "integer")
   expect_equal(some_data[1, ]$class_id, 15)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
 })
@@ -351,7 +377,7 @@ test_that("higher taxonomic ordering works for individual phenometrics", {
   expect_type(some_data$family_id, "integer")
   expect_equal(some_data[1, ]$family_id, 322)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
 
@@ -370,10 +396,9 @@ test_that("higher taxonomic ordering works for individual phenometrics", {
   expect_type(some_data$order_id, "integer")
   expect_equal(some_data[1, ]$order_id, 95)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
-
 
   # #class_ID
   vcr::use_cassette("npn_download_individual_phenometrics_tax_3", {
@@ -390,10 +415,9 @@ test_that("higher taxonomic ordering works for individual phenometrics", {
   expect_type(some_data$class_id, "integer")
   expect_equal(some_data[1, ]$class_id, 15)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
-
 })
 
 
@@ -419,7 +443,7 @@ test_that("higher taxonomic ordering works for site phenometrics", {
   expect_type(some_data$family_id, "integer")
   expect_equal(some_data[1, ]$family_id, 322)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
 
@@ -438,10 +462,9 @@ test_that("higher taxonomic ordering works for site phenometrics", {
   expect_type(some_data$order_id, "integer")
   expect_equal(some_data[1, ]$order_id, 95)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
-
 
   # #class_ID
   vcr::use_cassette("npn_download_site_phenometrics_tax_3", {
@@ -458,11 +481,9 @@ test_that("higher taxonomic ordering works for site phenometrics", {
   expect_type(some_data$class_id, "integer")
   expect_equal(some_data[1, ]$class_id, 15)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
-
-
 })
 
 
@@ -489,7 +510,7 @@ test_that("higher taxonomic ordering works for magnitude phenometrics", {
   expect_type(some_data$family_id, "integer")
   expect_equal(some_data[1, ]$family_id, 322)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
 
@@ -508,7 +529,7 @@ test_that("higher taxonomic ordering works for magnitude phenometrics", {
   expect_type(some_data$order_id, "integer")
   expect_equal(some_data[1, ]$order_id, 95)
 
-  less_data <- subset(some_data,species_id == 6)
+  less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
 
@@ -530,12 +551,10 @@ test_that("higher taxonomic ordering works for magnitude phenometrics", {
   less_data <- subset(some_data, species_id == 6)
   expect_lt(nrow(less_data), nrow(some_data))
   expect_gt(nrow(less_data), 0)
-
-
 })
 
 
-test_that("higher level taxonomic agg and pheno agg works for site level",{
+test_that("higher level taxonomic agg and pheno agg works for site level", {
   skip_on_cran()
   skip_if(skip_long_tests, "Skipping long tests")
   skip_if_not(check_service(), "Service is down")
@@ -555,13 +574,13 @@ test_that("higher level taxonomic agg and pheno agg works for site level",{
   expect_equal(some_data[1, ]$family_id, 322)
   expect_null(some_data$species_id)
 
-
   vcr::use_cassette("npn_download_site_phenometrics_pheno_agg_2", {
     some_data <- npn_download_site_phenometrics(
       request_source = "Unit Test",
       years = 2013,
       family_ids = c(322),
-      pheno_class_aggregate = TRUE, pheno_class_ids = c(1, 3, 6)
+      pheno_class_aggregate = TRUE,
+      pheno_class_ids = c(1, 3, 6)
     )
   })
 
@@ -585,8 +604,6 @@ test_that("higher level taxonomic agg and pheno agg works for site level",{
   expect_type(some_data$pheno_class_name, "character")
   expect_type(some_data$order_id, "integer")
   expect_null(some_data$phenophase_id)
-
-
 })
 
 test_that("higher level taxonomic agg works for magnitude", {
@@ -614,7 +631,8 @@ test_that("higher level taxonomic agg works for magnitude", {
       request_source = "Unit Test",
       years = 2013,
       family_ids = c(322),
-      pheno_class_aggregate = TRUE, pheno_class_ids = c(1, 3, 6)
+      pheno_class_aggregate = TRUE,
+      pheno_class_ids = c(1, 3, 6)
     )
   })
 
@@ -638,7 +656,6 @@ test_that("higher level taxonomic agg works for magnitude", {
   expect_type(some_data$pheno_class_name, "character")
   expect_type(some_data$order_id, "integer")
   expect_null(some_data$phenophase_id)
-
 })
 
 test_that("six concordance works for status", {
@@ -654,7 +671,10 @@ test_that("six concordance works for status", {
       six_leaf_layer = TRUE,
       six_bloom_layer = TRUE,
       agdd_layer = 32,
-      additional_layers = data.frame(name = c("si-x:30yr_avg_4k_leaf"), param = c("365"))
+      additional_layers = data.frame(
+        name = c("si-x:30yr_avg_4k_leaf"),
+        param = c("365")
+      )
     )
   })
 
@@ -691,7 +711,6 @@ test_that("six concordance works for status", {
   expect_lt(some_data[1, "SI-x_Leaf_Value"], 250)
   expect_false(identical(some_data$`SI-x_Leaf_Value`, avg_leaf_data))
 
-
   # This is testing that the implicit
   # reconciliation with different SI-x
   # layers is happening based on the date
@@ -723,7 +742,6 @@ test_that("six concordance works for status", {
 
   expect_gt(some_data[1, "SI-x_Leaf_Value"], -1)
   expect_lt(some_data[1, "SI-x_Leaf_Value"], 250)
-
 })
 
 
@@ -784,7 +802,6 @@ test_that("wkt filter works", {
   expect_equal(some_data[1, ]$state, "CO")
   expect_gt(rows_wo_filter, rows_w_filter)
 
-
   vcr::use_cassette("npn_download_site_phenometrics_wkt_1", {
     some_data <- npn_download_site_phenometrics(
       request_source = "Unit Test",
@@ -809,7 +826,6 @@ test_that("wkt filter works", {
   expect_equal(some_data[1, ]$state, "CO")
   expect_gt(rows_wo_filter, rows_w_filter)
 
-
   vcr::use_cassette("npn_download_magnitude_phenometrics_wkt_1", {
     some_data <- npn_download_magnitude_phenometrics(
       request_source = "Unit Test",
@@ -832,7 +848,6 @@ test_that("wkt filter works", {
   expect_s3_class(some_data, "data.frame")
   expect_type(some_data$species_id, "integer")
   expect_gt(rows_wo_filter, rows_w_filter)
-
 })
 
 
@@ -845,7 +860,8 @@ test_that("frequency params work", {
     some_data <- npn_download_site_phenometrics(
       request_source = "Unit Test",
       years = 2013,
-      family_ids = c(322), num_days_quality_filter = "30"
+      family_ids = c(322),
+      num_days_quality_filter = "30"
     )
   })
 
@@ -855,7 +871,8 @@ test_that("frequency params work", {
     some_data <- npn_download_site_phenometrics(
       request_source = "Unit Test",
       years = 2013,
-      family_ids = c(322), num_days_quality_filter = "15"
+      family_ids = c(322),
+      num_days_quality_filter = "15"
     )
   })
 
@@ -867,7 +884,8 @@ test_that("frequency params work", {
     some_data <- npn_download_magnitude_phenometrics(
       request_source = "Unit Test",
       years = 2013,
-      family_ids = c(322), period_frequency = "months"
+      family_ids = c(322),
+      period_frequency = "months"
     )
   })
 
@@ -877,11 +895,11 @@ test_that("frequency params work", {
     some_data <- npn_download_magnitude_phenometrics(
       request_source = "Unit Test",
       years = 2013,
-      family_ids = c(322), period_frequency = "14"
+      family_ids = c(322),
+      period_frequency = "14"
     )
   })
   rows_fortnight_freq <- nrow(some_data)
 
   expect_gt(rows_fortnight_freq, rows_month_freq)
-
 })

--- a/tests/testthat/test-npn-observations.R
+++ b/tests/testthat/test-npn-observations.R
@@ -149,7 +149,6 @@ test_that("phenometrics downloads work", {
 
   #remove one of these depending on which you decide to return on this error
   expect_equal(dl, dplyr::tibble())
-  expect_null(dl)
 })
 
 test_that("custom period works", {

--- a/tests/testthat/test-npn-observations.R
+++ b/tests/testthat/test-npn-observations.R
@@ -136,14 +136,16 @@ test_that("phenometrics downloads work", {
 
   expect_gt(num_mag_custom, num_mag_default)
 
-  expect_message(
-    dl <- npn_download_individual_phenometrics(
-      request_source = 'erinz',
-      years = 2009,
-      species_ids = 1612
-    ),
-    "No records in 2009"
-  )
+  vcr::use_cassette("npn_download_no_records", {
+    expect_message(
+      dl <- npn_download_individual_phenometrics(
+        request_source = 'erinz',
+        years = 2009,
+        species_ids = 1612
+      ),
+      "No records in 2009"
+    )
+  })
 
   #remove one of these depending on which you decide to return on this error
   expect_equal(dl, dplyr::tibble())

--- a/tests/testthat/test-npn-observations.R
+++ b/tests/testthat/test-npn-observations.R
@@ -147,7 +147,6 @@ test_that("phenometrics downloads work", {
     )
   })
 
-  #remove one of these depending on which you decide to return on this error
   expect_equal(dl, dplyr::tibble())
 })
 


### PR DESCRIPTION
Attemped fixes to address issue #122 (error messages that stopped any download of npn data when no records met the search criteria for one or more years).

Added ifelse conditions to `npn_get_data()` function that checks if any records were downloaded before manipulating data with `wrangle_dl_data()`. If there are no records, we'll create a NULL data object and print a message that no records were returned for that year.

Also needed to modify the `npn_get_data_by_year()` function to ensure that column headers appeared in csv file even if no records were downloaded for first requested year (assuming a download_path was specified). 

I tested these fixes with various search criteria for `npn_download_individual_phenometrics()`, `npn_download_site_phenometrics()`, and `npn_download_status_data()` with and without a specified download path. Everything seemed to be working correctly. I didn't do any other tests that @Aariq had set up previously with testthat since I'm not really familiar with that package. If needed, I can learn more about that and try to run the tests.