### PR TITLE
Dev vcr changes

### DIFF
--- a/tests/testthat/helper-rnpn.R
+++ b/tests/testthat/helper-rnpn.R
@@ -2,4 +2,3 @@ library("vcr")
 invisible(vcr::vcr_configure(
   dir = "../fixtures"
 ))
-vcr::check_cassette_names()


### PR DESCRIPTION
check_cassette_names is being deprecated, you can wait until the next version of vcr for it to be removed but might as well remove now. 

in addition, I see some errors running tests - i suggest installing dev vcr `pak::pak("ropensci/vcr")` and re-recording cassettes