### PR TITLE
Fix agdd raster download

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rnpn (development version)
 
+* Fixes a bug causing `npn_get_custom_agdd_raster()` to fail ([#112](https://github.com/usa-npn/rnpn/issues/112)
 * -9999 is now converted to `NA` for all columns in data returned by `npn_download_*()` functions (#119, #121).
 * compatibility with vcr v2.0.0 (fixed in #125 by @skott)
 

--- a/R/base-reqs.R
+++ b/R/base-reqs.R
@@ -1,7 +1,7 @@
 #base url for NPN Portal
 base_portal_url <- "https://services.usanpn.org/npn_portal/"
 #base url for geoserver
-base_geoserver_url <- "http://geoserver.usanpn.org/geoserver/"
+base_geoserver_url <- "https://geoserver.usanpn.org/geoserver/"
 #base url for geoservices
 base_geoservices_url <- "https://services.usanpn.org/geo-services/v1/"
 


### PR DESCRIPTION
I think this might fix #112. It looks like this download is no longer a two-step process but rather the first request to /geoservices/v1/agdd now returns a geotiff.  I got it to work once for me, but now am getting HTTP 500 Internal Server Error. @ezylstra, would you try this out?